### PR TITLE
Update apt-utils.el

### DIFF
--- a/apt-utils.el
+++ b/apt-utils.el
@@ -1040,7 +1040,7 @@ a choice."
         (let ((process-environment (append '("COLUMNS=200") (copy-alist process-environment))))
           (call-process apt-utils-dpkg-program nil t nil "-l" package))
         (when (re-search-backward
-               (format "^\\([a-z ][a-z ][a-z ]\\)\\s-+%s\\s-+\\(\\S-+\\)"
+               (format "^\\([a-z ][a-z ][a-z ]\\)\\s-+%s\\(?:\\s-+\\|:\\)\\(\\S-+\\)"
                        (regexp-quote package)) nil t)
           (progn
             (setq desired (aref (match-string 1) 0)


### PR DESCRIPTION
Handle :amd64, etc. appended to package name in Name column of dpkg output. Without this apt-utils-get-installed-info returns nil when checking whether such a package is installed.