### PR TITLE
Do not use any longer default-fill-column

### DIFF
--- a/scilab.el
+++ b/scilab.el
@@ -192,7 +192,7 @@
 (require 'tempo)
 (require 'derived)
 
-(defconst scilab-mode-version "2.1.27quad(V. Bela�che)"
+(defconst scilab-mode-version "2.1.28(V. Belaïche)"
  "Current version of Scilab mode.")
 (defvar scilab-mode-all-versions nil
  "Current status of Scilab mode, Emacs/Xemacs and existence of client.")
@@ -1558,7 +1558,6 @@ All Key Bindings:
  (make-local-variable 'comment-indent-function)
  (setq comment-indent-function 'scilab-comment-indent)
  (make-local-variable 'fill-column)
- (setq fill-column default-fill-column)
  (make-local-variable 'auto-fill-function)
  (make-local-variable 'which-func-format)
  (setq which-func-format scilab-which-func-format)


### PR DESCRIPTION
Ohterwise one gets this error message:

```
File mode specification error: (void-variable default-fill-column)
scilab-mode: Symbol’s value as variable is void: default-fill-column
```

Thanks for your interest in contributing to this package.

This repository is only a mirror.  Please do not open a pull-request here.  Instead figure out where the upstream repository is and open a pull-request there.  If the upstream repository is located on Github, then you should see a link "forked from somebody-else/this-project" should be visible above and that link should take you there.
