### PR TITLE
Fix typopunct to avoid deprecated positional arguments warning

### DIFF
--- a/typopunct.el
+++ b/typopunct.el
@@ -230,10 +230,9 @@ typographical convention.
 
 Note that you may always type `C-q C-\"', `C-q C-\' or `C-q C--' to
 insert the default ASCII characters."
-  nil
-  " Typo"
-  typopunct-map)
-
+:init-value nil
+:lighter " Typo"
+:keymap typopunct-map)
 
 (defun typopunct-change-language (language &optional default)
   "Change language assumed by `typopunct-mode' to LANGUAGE.


### PR DESCRIPTION
Avoids the `Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'` in latest emacs versions.

Thanks for your interest in contributing to this package.

This repository is only a mirror.

⚠️ Please do not open a pull-request here! ⚠️

🆘 Visit https://emacsmirror.net/stats/upstreams.html to look up the homepage or upstream repository of this package.

(If you are opening a pull-request at https://github.com/emacsmirror/.github, then please disregard the above.  It does not apply in that case, but for technical reasons I cannot prevent it from being shown to you anyway.)

